### PR TITLE
Dont destroy cache on each setup

### DIFF
--- a/vagga.yaml
+++ b/vagga.yaml
@@ -16,12 +16,13 @@ containers:
         setup:
             - !Container base
             - !Env HOME: /work/.vagga/nightly-home
-            - !Sh rm -rf $HOME/.rustup $HOME/.cargo
             - !Sh curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host x86_64-unknown-linux-gnu --default-toolchain nightly --no-modify-path
             - !Env PATH: /bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/work/.vagga/nightly-home/.cargo/bin
-            - !Sh cargo install rustfmt
-            - !Sh cargo install clippy
-            - !Sh cd $HOME; git clone https://github.com/davisp/ghp-import.git
+            - !Sh rustup update
+            - !Sh cargo install -f --git https://github.com/hecal3/cargo-install-upgrade
+            - !Sh cargo install rustfmt || cargo install-upgrade
+            - !Sh cargo install -f clippy
+            - !Sh cd $HOME; rm -rf ghp-import; git clone https://github.com/davisp/ghp-import.git
 
 commands:
     check-fmt: !Command
@@ -78,5 +79,5 @@ commands:
         container: nightly
         run: |
             rustup update
-            cargo install -f rustfmt
+            cargo install-upgrade
             cargo install -f clippy


### PR DESCRIPTION
I totally forget I did cleanup `rustup`s and `cargo`s directory on startup. Travis cache is of course totally useless like this.

This PR fixes the vagga.yaml to work with an already initialized $HOME directory and removes the initial cleanup to speed up travis build times.